### PR TITLE
add plugins from nushell's crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A curated list of awesome tools that work within the nu language ecosystem e.g. 
 ## Plugins
 You can find some examples about how to create and use plugins in the [Nushell Plugins](https://www.nushell.sh/book/plugins.html) page.
 - [nu_plugin_periodic_table](https://crates.io/crates/nu_plugin_periodic_table): A periodic table of elements plugin.
+- [nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query): Query json, xml and web pages.
+- [nu_plugin_inc](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc): Plugin to increment semantic versioning strings.
+- [nu_plugin_gstat](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat): Show the git working tree status.
 
 ## Scripts
 You can find some examples about how to create and use scripts in the [Nushell Scripts](https://www.nushell.sh/book/scripts.html) page.


### PR DESCRIPTION
I skipped `nu_plugin_example` and `nu_plugin_python` because they are (or look like) examples.