### PR TITLE
Add nu_plugin_dpkgtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_image](https://github.com/FMotalleb/nu_plugin_image): A nushell plugin to open png images in the shell and save ansi string as images.
 - [nu_plugin_semver](https://github.com/abusch/nu_plugin_semver): A Nushell plugin to manipulate SemVer versions.
 - [nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus): Nushell plugin for interacting with D-Bus.
+- [nu_plugin_dpktable](https://github.com/pdenapo/nu_plugin_dpkgtable.git): Gets a table of all known packages in a Debian GNU/Linux system.
 
 > If the shell freezes while registering the command, that means the plugin is using an older Nu version no longer compatible with your current version. Consider bumping the Nu version to the latest in the `cargo.toml`, (may lead to breaking the script).
 

--- a/config.yaml
+++ b/config.yaml
@@ -228,7 +228,13 @@ plugins:
     language: rust
     repository:
       url: https://github.com/devyn/nu_plugin_dbus
-      branch: main      
+      branch: main
+  - name: nu_plugin_dpkgtable
+    language: rust
+    repository:
+        url: https://github.com/pdenapo/nu_plugin_dpkgtable.git
+        branch: main
+      
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)
 #    language: python # programming language (mandatory)


### PR DESCRIPTION
This a plugin to convert the output of dpkg --list  (given the list of known packages in a GNU/Linux Debian system) to a nushell table