### PR TITLE
Fix: Handle .git extensions in repository URLs

### DIFF
--- a/action.nu
+++ b/action.nu
@@ -151,8 +151,11 @@ export module plugin-list {
     # TODO handle error
     def "get self or version" []: record -> string , string -> string {
         let input = $in
+        
         if ($input | is-str) {
             return $input;
+        } else if ($input.version? | is-empty) {
+            return "0.0.0"
         } else {
             return $input.version
         }

--- a/action.nu
+++ b/action.nu
@@ -133,8 +133,7 @@ export module plugin-list {
     def "get-toml" [
         branch: string # branch name (e.g. main)
     ]: string -> record {
-        let git_repo = ($in | str replace ".git" "") # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
-
+        let git_repo = ($in |  str replace --regex ".git$" "") # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
         let toml_file_address: string = (get-raw-toml-address $git_repo $branch | url join)
         try {
             return (http get --raw $toml_file_address | from toml) 

--- a/action.nu
+++ b/action.nu
@@ -133,7 +133,8 @@ export module plugin-list {
     def "get-toml" [
         branch: string # branch name (e.g. main)
     ]: string -> record {
-        let git_repo = $in # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
+        let git_repo = ($in | str replace ".git" "") # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
+
         let toml_file_address: string = (get-raw-toml-address $git_repo $branch | url join)
         try {
             return (http get --raw $toml_file_address | from toml) 
@@ -167,7 +168,7 @@ export module plugin-list {
         repository: string
     ]: record -> record {
         let toml: record = $in
-        if ([$toml.package?, $toml.dependencies?] | all {|i| $i != null}  ) {
+        if ([$toml.package?, $toml.dependencies?] | all {|i| $i != null}) {
             return {
                 name: $"[($toml.package.name)]\(($repository)\)" 
                 version: $toml.package.version

--- a/config.yaml
+++ b/config.yaml
@@ -232,14 +232,13 @@ plugins:
   - name: nu_plugin_dpkgtable
     language: rust
     repository:
-        url: https://github.com/pdenapo/nu_plugin_dpkgtable.git
-        branch: main
+      url: https://github.com/pdenapo/nu_plugin_dpkgtable
+      branch: main
   - name: nu_plugin_from_sse
     language: rust
     repository:
       url: https://github.com/cablehead/nu_plugin_from_sse
       branch: main
-      
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)
 #    language: python # programming language (mandatory)


### PR DESCRIPTION
Fixing an error reported https://github.com/nushell/awesome-nu/pull/32#issuecomment-2067715335

The main issue was that one of the plugins in the config file had a .git extension at the end of the repository URL.
https://github.com/nushell/awesome-nu/blob/65af689a1ba7ea97d105be0ccb45ae0f68072b73/config.yaml#L235

To address this issue, we implemented two steps:
1. The script will now replace `.git` extensions with an empty string in URLs, ensuring that the script can correctly locate the `Cargo.toml` file.
2. If this issue arises again in the future, the script will handle it more robustly by omitting the affected plugin's data instead of crashing entirely.