### PR TITLE
Add mise to the list of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Other tools that work with or within the nu language ecosystem.
 - [broot](https://github.com/Canop/broot): A new way to see and navigate directory trees.
 - [nur](https://github.com/ddanier/nur): A taskrunner based on nu shell.
 - [pspg](https://github.com/okbob/pspg): A postgres pager that integrates in nushell.
+- [mise](https://mise.jdx.dev/): A development environment setup tool (dev tools, env vars, task runner) that integrates with Nushell.
 
 ## Editor Extensions
 Plugins and Extensions that you can use in other text editors


### PR DESCRIPTION
mise is a tool that integrates into the shell,
providing a way to manage (globally and project-specific) dev tools and env vars, and can be used as a task runner.

It may appeal to Nushell users,
as it's popular, written in rust, and supports Nushell.

- nushell specific info: https://mise.jdx.dev/getting-started.html#nushell
- source code: https://github.com/jdx/mise