### PR TITLE
chore: bump nushell version to 0.95.0

### DIFF
--- a/.github/workflows/update-results.yaml
+++ b/.github/workflows/update-results.yaml
@@ -15,7 +15,7 @@ jobs:
         -   name: Setup Nushell
             uses: hustcer/setup-nu@v3.8
             with:
-              version: 0.87.0
+              version: 0.95.0
               token: ${{ secrets.GITHUB_TOKEN }}
         -   uses: actions/checkout@v2
         -   name: Update plugin list

--- a/plugin_details.md
+++ b/plugin_details.md
@@ -1,51 +1,51 @@
 |name|version|description|plugin|protocol|
 |-|-|-|-|-|
 |[nu-plugin-bexpand](https://codeberg.org/Taywee/nu-plugin-bexpand)|1.3.5|A brace expansion plugin compatible with Bash for nushell|⚠️0.92|⚠️0.92|
-|[nu_plugin_audio_hook](https://github.com/FMotalleb/nu_plugin_audio_hook)|0.2.0|A nushell plugin to make and play sounds|⚠️0.94|⚠️0.94|
+|[nu_plugin_audio_hook](https://github.com/FMotalleb/nu_plugin_audio_hook)|0.2.1|A nushell plugin to make and play sounds|✅0.95|✅0.95|
 |[nu_plugin_bash_env](https://github.com/tesujimath/nu_plugin_bash_env)|0.10.0|A Bash environment plugin for Nushell.|⚠️0.94.1|⚠️0.94.1|
 |[nu_plugin_bin_reader](https://github.com/WindSoilder/nu_plugin_bin_reader)|0.0.0|A high level, general binary data reader.|⛔0.0|⛔0.0|
 |[nu_plugin_bio](https://github.com/Euphrasiologist/nu_plugin_bio)|0.85.0|Parse and manipulate common bioinformatic formats in nushell.|⚠️0.85.0|⚠️0.85.0|
-|[nu_plugin_clipboard](https://github.com/FMotalleb/nu_plugin_clipboard)|0.94.1|A nushell plugin to copy text into clipboard or get text from it.|⚠️0.94.1|⚠️0.94.1|
-|[nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus)|0.7.0|Nushell plugin for communicating with D-Bus|⚠️0.94.0|⚠️0.94.0|
+|[nu_plugin_clipboard](https://github.com/FMotalleb/nu_plugin_clipboard)|0.95.0|A nushell plugin to copy text into clipboard or get text from it.|✅0.95.0|✅0.95.0|
+|[nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus)|0.8.0|Nushell plugin for communicating with D-Bus|✅0.95.0|✅0.95.0|
 |[nu_plugin_dcm](https://github.com/realcundo/nu_plugin_dcm)|0.1.8|A nushell plugin to parse Dicom files|⚠️0.68|⚠️0.68|
-|[nu_plugin_desktop_notifications](https://github.com/FMotalleb/nu_plugin_desktop_notifications)|1.2.0|A nushell plugin to send desktop notifications|⚠️0.94.0|⚠️0.94.0|
+|[nu_plugin_desktop_notifications](https://github.com/FMotalleb/nu_plugin_desktop_notifications)|1.2.1|A nushell plugin to send desktop notifications|✅0.95.0|✅0.95.0|
 |[nu_plugin_dialog](https://github.com/Trivernis/nu-plugin-dialog)|0.2.0|A nushell plugin for user interaction|⚠️0.86.1|⚠️0.86.1|
 |[nu_plugin_dns](https://github.com/dead10ck/nu_plugin_dns)|3.0.2-alpha.1|A DNS utility for nushell|⚠️0.94.2|⚠️0.94.2|
 |[nu_plugin_dpkgtable](https://github.com/pdenapo/nu_plugin_dpkgtable)|0.1.0||⚠️0.91.0|⚠️0.91.0|
-|[nu_plugin_emoji](https://github.com/fdncred/nu_plugin_emoji)|0.5.0|a nushell plugin called emoji|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_emoji](https://github.com/fdncred/nu_plugin_emoji)|0.5.0|a nushell plugin called emoji|✅0.95.1|✅0.95.1|
 |[nu_plugin_explore](https://github.com/amtoine/nu_plugin_explore)|0.94.0|A fast structured data explorer for Nushell.|⚠️0.94.0|⚠️0.94.0|
-|[nu_plugin_file](https://github.com/fdncred/nu_plugin_file)|0.5.0|a nushell plugin called file|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_file](https://github.com/fdncred/nu_plugin_file)|0.5.0|a nushell plugin called file|✅0.95.1|✅0.95.1|
 |[nu_plugin_formats](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats)|0.95.1|An I/O plugin for a set of file formats for Nushell|✅0.95.1|✅0.95.1|
 |[nu_plugin_from_beancount](https://github.com/jcornaz/nu_plugin_from_beancount)|2.0.0|A nushell extension to load a beancount file into nu structured data|⚠️0.84.0|⚠️0.84.0|
 |[nu_plugin_from_bencode](https://github.com/bluk/nu_plugin_from_bencode)|0.11.0|A Nushell plugin to convert bencode data into Nu structured values.|⚠️0.93|⚠️0.93|
 |[nu_plugin_from_hdf5](https://github.com/Berrysoft/nu_plugin_from_hdf5)|0.1.0|A plugin to parse HDF5 files into nushell record.|⚠️0.89|⚠️0.89|
-|[nu_plugin_from_parquet](https://github.com/fdncred/nu_plugin_from_parquet)|0.5.0|nu plugin to add parquet support|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_from_parquet](https://github.com/fdncred/nu_plugin_from_parquet)|0.5.0|nu plugin to add parquet support|✅0.95.1|✅0.95.1|
 |[nu_plugin_from_sse](https://github.com/cablehead/nu_plugin_from_sse)|0.3.0|Nushell plugin to convert a HTTP server sent event stream to structured data|⚠️0.94|⚠️0.94|
 |[nu_plugin_gstat](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat)|0.95.1|A git status plugin for Nushell|✅0.95.1|✅0.95.1|
 |[nu_plugin_hcl](https://github.com/Yethal/nu_plugin_hcl)|0.90.1|A nushell plugin for parsing Hashicorp Configuration Language file format|⚠️0.90.1|⚠️0.90.1|
-|[nu_plugin_highlight](https://github.com/cptpiepmatz/nu-plugin-highlight)|1.1.4+0.94.0|A nushell plugin for syntax highlighting|⚠️0.94|⚠️0.94|
-|[nu_plugin_hmac](https://github.com/fnuttens/nu_plugin_hmac)|0.6.0||⚠️0.94.0|⚠️0.94.0|
-|[nu_plugin_image](https://github.com/FMotalleb/nu_plugin_image)|0.5.1|A nushell plugin to open png images in the shell and save ansi string as images (like tables or ...)|⚠️0.94.0|⚠️0.94.0|
+|[nu_plugin_highlight](https://github.com/cptpiepmatz/nu-plugin-highlight)|1.2.0+0.95.0|A nushell plugin for syntax highlighting|✅0.95|✅0.95|
+|[nu_plugin_hmac](https://github.com/fnuttens/nu_plugin_hmac)|0.7.0||✅0.95.0|✅0.95.0|
+|[nu_plugin_image](https://github.com/FMotalleb/nu_plugin_image)|0.5.2|A nushell plugin to open png images in the shell and save ansi string as images (like tables or ...)|✅0.95.0|✅0.95.0|
 |[nu_plugin_inc](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc)|0.95.1|A version incrementer plugin for Nushell|✅0.95.1|✅0.95.1|
-|[nu_plugin_json_path](https://github.com/fdncred/nu_plugin_json_path)|0.5.0|a nushell plugin created to parse json files using jsonpath|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_json_path](https://github.com/fdncred/nu_plugin_json_path)|0.5.0|a nushell plugin created to parse json files using jsonpath|✅0.95.1|✅0.95.1|
 |[nu_plugin_kdl](https://github.com/amtoine/nu_plugin_kdl)|0.83.2|Add support for the KDL data format to Nushell.|⚠️0.83.2|⚠️0.83.2|
 |[nu_plugin_msgpack](https://github.com/hulthe/nu_plugin_msgpack)|0.90.1|Commands to convert nushell data to and from MsgPack|⚠️0.90.1|⚠️0.90.1|
 |[nu_plugin_net](https://github.com/fennewald/nu_plugin_net)|1.5.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.94.2|⚠️0.94.2|
 |[nu_plugin_periodic_table](https://github.com/JosephTLyons/nu_plugin_periodic_table)|0.2.8|A periodic table of elements plugin for Nushell|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_plist](https://github.com/ayax79/nu_plugin_plist)|0.94.0|Plist parsing for nushell|⚠️0.94|⚠️0.94|
 |[nu_plugin_plot](https://github.com/Euphrasiologist/nu_plugin_plot)|0.91.1|Plot graphs in nushell using numerical lists.|⚠️0.92.2|⚠️0.92.2|
-|[nu_plugin_pnet](https://github.com/fdncred/nu_plugin_pnet)|1.7.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.94.3|⚠️0.94.3|
-|[nu_plugin_port_list](https://github.com/FMotalleb/nu_plugin_port_list)|1.4.0|A nushell plugin to list all active connections|⚠️0.94.0|⚠️0.94.0|
-|[nu_plugin_port_scan](https://github.com/FMotalleb/nu_plugin_port_scan)|1.2.0|A nushell plugin for scanning ports on a target|⚠️0.94.0|⚠️0.94.0|
-|[nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)|0.2.0|A nushell plugin for querying prometheus|⚠️0.94.2|⚠️0.94.2|
+|[nu_plugin_pnet](https://github.com/fdncred/nu_plugin_pnet)|1.7.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|✅0.95.1|✅0.95.1|
+|[nu_plugin_port_list](https://github.com/FMotalleb/nu_plugin_port_list)|1.4.1|A nushell plugin to list all active connections|✅0.95.0|✅0.95.0|
+|[nu_plugin_port_scan](https://github.com/FMotalleb/nu_plugin_port_scan)|1.2.1|A nushell plugin for scanning ports on a target|✅0.95.0|✅0.95.0|
+|[nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)|0.3.0|A nushell plugin for querying prometheus|✅0.95.0|✅0.95.0|
 |[nu_plugin_qr_maker](https://github.com/FMotalleb/nu_plugin_qr_maker)|1.1.0|A nushell plugin to create qr code in terminal|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query)|0.95.1|A Nushell plugin to query JSON, XML, and various web data|✅0.95.1|✅0.95.1|
-|[nu_plugin_regex](https://github.com/fdncred/nu_plugin_regex)|0.5.0|nu plugin to search text with regex|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_regex](https://github.com/fdncred/nu_plugin_regex)|0.5.0|nu plugin to search text with regex|✅0.95.1|✅0.95.1|
 |[nu_plugin_semver](https://github.com/abusch/nu_plugin_semver)|0.5.0|A nushell plugin for dealing with SemVer versions|✅0.95.0|✅0.95.0|
 |[nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim)|0.1.1|An `sk` command that can handle Nushell's structured data|⚠️0.94|⚠️0.94|
-|[nu_plugin_str_similarity](https://github.com/fdncred/nu_plugin_str_similarity)|0.5.0|a nushell plugin called str_similarity|⚠️0.94.3|⚠️0.94.3|
+|[nu_plugin_str_similarity](https://github.com/fdncred/nu_plugin_str_similarity)|0.5.0|a nushell plugin called str_similarity|✅0.95.1|✅0.95.1|
 |[nu_plugin_template](https://github.com/fdncred/nu_plugin_template)|0.0|A `cargo-generate` template for making it easier to create nushell plugins.|⛔0.0|⛔0.0|
 |[nu_plugin_ulid](https://github.com/lizclipse/nu_plugin_ulid)|0.4.0|A nushell plugin that adds various ulid commands|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_units](https://github.com/JosephTLyons/nu_plugin_units)|0.1.1|A Nushell plugin for easily converting between common units|⚠️0.94.0|⚠️0.94.0|
 
-last update at `2024-06-26 03:11:56 +00:00`
+last update at `2024-06-27 07:27:13 +00:00`


### PR DESCRIPTION
As described in the title the only change is updating github action's nushell version to 0.95.0

and the [plugin_details.md](https://github.com/FMotalleb/awesome-nu/blob/main/plugin_details.md) file is updated (to test the action)