### PR TITLE
Fix nu_plugin_endecode YAML config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -267,8 +267,11 @@ plugins:
   - name: nu_plugin_endecode
     language: rust
     repository:
-      url: https://codeberg.org/kaathewise/nu-plugin/src/branch/trunk
+      url: https://codeberg.org/kaathewise/nu-plugin/src/branch/trunk/endecode
       branch: trunk
+    override:
+      plugin: "0.97.1"
+      protocol: "0.97.1"
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)
 #    language: python # programming language (mandatory)


### PR DESCRIPTION
I had to override plugin and protocol version, because I use a monorepo setup, so the versions are defined in a unified workspace file.  This should be merged together with #64, but before running the CI again.