### PR TITLE
fix action.nu for self-hosted forges

### DIFF
--- a/action.nu
+++ b/action.nu
@@ -80,20 +80,16 @@ export module plugin-list {
     def "get-raw-toml-address" [
         url: string, # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
         branch: string, # branch name (e.g. main)
-        software?: string,
+        software?: string
     ]: nothing -> record {
         let url: record = ($url | url parse)
 
         # Unspecified forge software is determined from the host.
-        let software = if $software == null {
-            let foo = match $url.host {
-                'github.com' => 'github',
-                'gitlab.com' => 'gitlab',
-                'codeberg.org' => 'forgejo',
-            }
-            $foo
-        } else {
-            $software
+        let software = match $url.host {
+            'github.com' => 'github',
+            'gitlab.com' => 'gitlab',
+            'codeberg.org' => 'forgejo',
+            _ => $software
         }
         use utils "str explode"
         match $software {
@@ -150,8 +146,8 @@ export module plugin-list {
 
     # download toml file from repository
     def "get-toml" [
-        branch: string # branch name (e.g. main)
-        software?: string,
+        branch: string, # branch name (e.g. main)
+        software?: string
     ]: string -> record {
         let git_repo = ($in |  str replace --regex ".git$" "") # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
         let toml_file_address: string = (get-raw-toml-address $git_repo $branch $software | url join)
@@ -184,7 +180,7 @@ export module plugin-list {
 
     # map `Cargo.toml` file to a plugin entry record
     def "map-toml-to-entry" [
-        repository: string,
+        repository: string
     ]: record -> record {
         let toml: record = $in
         if ([$toml.package?, $toml.dependencies?] | all {|i| $i != null}) {

--- a/action.nu
+++ b/action.nu
@@ -79,12 +79,25 @@ export module plugin-list {
     # converts repository url into raw download link for Cargo.toml
     def "get-raw-toml-address" [
         url: string, # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
-        branch: string # branch name (e.g. main)
+        branch: string, # branch name (e.g. main)
+        software?: string,
     ]: nothing -> record {
         let url: record = ($url | url parse)
+
+        # Unspecified forge software is determined from the host.
+        let software = if $software == null {
+            let foo = match $url.host {
+                'github.com' => 'github',
+                'gitlab.com' => 'gitlab',
+                'codeberg.org' => 'forgejo',
+            }
+            $foo
+        } else {
+            $software
+        }
         use utils "str explode"
-        match $url.host {
-            'github.com' => {
+        match $software {
+            'github' => {
                 if ( ($url.path | str explode '/' --trim-end | length) > 3 ) {
                     return ($url
                     | upsert host raw.githubusercontent.com
@@ -102,7 +115,7 @@ export module plugin-list {
                         | append Cargo.toml
                         | str join '/'))
              },
-             'gitlab.com' => {
+             'gitlab' => {
                 return ($url
                     | upsert path ($url.path
                     | str explode '/' --trim-end
@@ -112,7 +125,7 @@ export module plugin-list {
                     | append Cargo.toml
                     | str join '/'))
              },
-            'codeberg.org' => {
+            'forgejo' => {
                 return ($url
                     | update path {
                         split row "/"
@@ -138,9 +151,10 @@ export module plugin-list {
     # download toml file from repository
     def "get-toml" [
         branch: string # branch name (e.g. main)
+        software?: string,
     ]: string -> record {
         let git_repo = ($in |  str replace --regex ".git$" "") # github repository url (e.g. https://github.com/FMotalleb/nu_plugin_port_scan)
-        let toml_file_address: string = (get-raw-toml-address $git_repo $branch | url join)
+        let toml_file_address: string = (get-raw-toml-address $git_repo $branch $software | url join)
         try {
             return (http get --raw $toml_file_address | from toml)
         } catch {
@@ -170,7 +184,7 @@ export module plugin-list {
 
     # map `Cargo.toml` file to a plugin entry record
     def "map-toml-to-entry" [
-        repository: string
+        repository: string,
     ]: record -> record {
         let toml: record = $in
         if ([$toml.package?, $toml.dependencies?] | all {|i| $i != null}) {
@@ -244,7 +258,7 @@ export module plugin-list {
         let item = $in
         match $item.language {
             "rust" => {
-                return ($item.repository.url | get-toml $item.repository.branch| map-toml-to-entry $item.repository.url)
+                return ($item.repository.url | get-toml $item.repository.branch ($item | get -i $.repository.software) | map-toml-to-entry $item.repository.url)
             }
             _ => {
                 return {}

--- a/config.yaml
+++ b/config.yaml
@@ -141,6 +141,7 @@ plugins:
     repository:
       url: https://forge.axfive.net/Taylor/nu-plugin-bexpand
       branch: main
+      software: forgejo
   - name: nu_plugin_highlight
     language: rust
     repository:


### PR DESCRIPTION
Plugins broke if their forge wasn't in a hard-coded list.  They are changed to be able to specify their forge software explicitly, so they can be pulled without being added to the list.

The hardcoded list still exists for the most common cases.

closes #94 