### PR TITLE
chore: remove nu_plugin_from_sse

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_from_beancount](https://github.com/jcornaz/nu_plugin_from_beancount): A nushell extension to load a beancount file into nu structured data.
 - [nu_plugin_from_bencode](https://github.com/bluk/nu_plugin_from_bencode): A converter plugin from the bencode format for Nushell.
 - [nu_plugin_from_hdf5](https://github.com/Berrysoft/nu_plugin_from_hdf5): A plugin to parse HDF5 files into nushell record.
-- [nu_plugin_from_sse](https://github.com/cablehead/nu_plugin_from_sse): Nushell plugin to parse a stream of HTTP server sent events.
 - [nu_plugin_gstat](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat): Show the git working tree status.
 - [nu_plugin_hashes](https://crates.io/crates/nu_plugin_hashes): A plugin that adds hash functions from the [hashes](https://github.com/RustCrypto/hashes) project.
 - [nu_plugin_hcl](https://github.com/Yethal/nu_plugin_hcl): A Hashicorp Configuration Language plugin for nushell.

--- a/config.yaml
+++ b/config.yaml
@@ -239,11 +239,6 @@ plugins:
     repository:
       url: https://github.com/pdenapo/nu_plugin_dpkgtable
       branch: main
-  - name: nu_plugin_from_sse
-    language: rust
-    repository:
-      url: https://github.com/cablehead/nu_plugin_from_sse
-      branch: main
   - name: nu_plugin_ulid
     language: rust
     repository:


### PR DESCRIPTION
As of Nushell [0.102.0](https://www.nushell.sh/blog/2025-02-04-nushell_0_102_0.html#generate-with-input-toc) `nu`'s [`generate`](https://www.nushell.sh/commands/docs/generate.html) command now supports stateful aggregation. This means a plugin for things like `from sse` is no longer required. You can achieve the same result with a custom command similar to:

```nushell
export def "from sse" [] {
  lines | generate {|line pending = {data: []}|

    match ($line | split row -n 2 ":" | each { str trim }) {
      [$prefix $content] if $prefix == "id" => {
        return {next: ($pending | upsert id $content)}
      }

      [$prefix $content] if $prefix == "event" => {
        return {next: ($pending | upsert event $content)}
      }

      [$prefix $content] if $prefix == "data" => {
        return {next: ($pending | update data { append $content })}
      }

      [$empty] if $empty == "" => {
        if ($pending == {data: []}) {
          return {next: $pending}
        }
        return {next: {data: []} out: ($pending | update data { str join "\n" })}
      }

      _ => { error make {msg: $"unexpected: ($line)"} }
    }
  }
}
```