### PR TITLE
Deprecation of (nu_plugin_port_scan and nu_plugin_port_list) in favor of nu_plugin_port_extension

### DIFF
--- a/.github/workflows/update-results.yaml
+++ b/.github/workflows/update-results.yaml
@@ -15,7 +15,7 @@ jobs:
         -   name: Setup Nushell
             uses: hustcer/setup-nu@v3
             with:
-              version: 0.101.0
+              version: 0.102.0
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         -   uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_plist by ayax79](https://github.com/ayax79/nu_plugin_plist): A plist plugin for nushell.
 - [nu_plugin_plot](https://github.com/Euphrasiologist/nu_plugin_plot): A terminal plotting plugin for nushell.
 - [nu_plugin_plotters](https://github.com/cptpiepmatz/nu-jupyter-kernel/tree/main/crates/nu_plugin_plotters): A nushell plugin for plotting charts.
-- [nu_plugin_port_list](https://github.com/FMotalleb/nu_plugin_port_list): A nushell plugin to list all active connections.
-- [nu_plugin_port_scan](https://github.com/FMotalleb/nu_plugin_port_scan): A nushell plugin for scanning ports on a target.
+- [nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension): A nushell plugin to list all active connections and scanning ports on a target address (replacement of both nu_plugin_port_scan and nu_plugin_port_list since 0.102).
 - [nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus): Prometheus querying for nushell.
 - [nu_plugin_qr_maker](https://github.com/FMotalleb/nu_plugin_qr_maker): A nushell plugin to create QR codes in terminal.
 - [nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query): Query json, xml and web pages.

--- a/config.yaml
+++ b/config.yaml
@@ -172,16 +172,6 @@ plugins:
     repository:
       url: https://github.com/dead10ck/nu_plugin_dns
       branch: main
-  # - name: nu_plugin_port_scan
-  #   language: rust
-  #   repository:
-  #     url: https://github.com/FMotalleb/nu_plugin_port_scan
-  #     branch: main
-  # - name: nu_plugin_port_list
-  #   language: rust
-  #   repository:
-  #     url: https://github.com/FMotalleb/nu_plugin_port_list
-  #     branch: main
   - name: nu_plugin_audio_hook
     language: rust
     repository:

--- a/config.yaml
+++ b/config.yaml
@@ -172,16 +172,16 @@ plugins:
     repository:
       url: https://github.com/dead10ck/nu_plugin_dns
       branch: main
-  - name: nu_plugin_port_scan
-    language: rust
-    repository:
-      url: https://github.com/FMotalleb/nu_plugin_port_scan
-      branch: main
-  - name: nu_plugin_port_list
-    language: rust
-    repository:
-      url: https://github.com/FMotalleb/nu_plugin_port_list
-      branch: main
+  # - name: nu_plugin_port_scan
+  #   language: rust
+  #   repository:
+  #     url: https://github.com/FMotalleb/nu_plugin_port_scan
+  #     branch: main
+  # - name: nu_plugin_port_list
+  #   language: rust
+  #   repository:
+  #     url: https://github.com/FMotalleb/nu_plugin_port_list
+  #     branch: main
   - name: nu_plugin_audio_hook
     language: rust
     repository:
@@ -352,7 +352,12 @@ plugins:
     repository:
       url: https://github.com/devyn/nu_plugin_cassandra_query
       branch: main
-
+  - name: nu_plugin_port_extension
+    language: rust
+    repository:
+      url: https://github.com/FMotalleb/nu_plugin_port_extension
+      branch: main
+  
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)
 #    language: python # programming language (mandatory)

--- a/plugin_details.md
+++ b/plugin_details.md
@@ -1,68 +1,66 @@
 |name|version|description|plugin|protocol|
 |-|-|-|-|-|
-|[nu-plugin-bexpand](https://forge.axfive.net/Taylor/nu-plugin-bexpand)|1.3.10101|A brace expansion plugin compatible with Bash for nushell|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_audio_hook](https://github.com/FMotalleb/nu_plugin_audio_hook)|0.2.8|A nushell plugin to make and play sounds|⚠️0.101.0|⚠️0.101.0|
+|[nu-plugin-bexpand](https://forge.axfive.net/Taylor/nu-plugin-bexpand)|1.3.10200|A brace expansion plugin compatible with Bash for nushell|✅0.102.0|✅0.102.0|
+|[nu_plugin_audio_hook](https://github.com/FMotalleb/nu_plugin_audio_hook)|0.102.0|A nushell plugin to make and play sounds|✅0.102.0|✅0.102.0|
 |[nu_plugin_bin_reader](https://github.com/WindSoilder/nu_plugin_bin_reader)|0.0.0|A high level, general binary data reader.|⛔0.0|⛔0.0|
 |[nu_plugin_bio](https://github.com/Euphrasiologist/nu_plugin_bio)|0.85.0|Parse and manipulate common bioinformatic formats in nushell.|⚠️0.85.0|⚠️0.85.0|
 |[nu_plugin_cassandra_query](https://github.com/devyn/nu_plugin_cassandra_query)|0.3.0|Query plugin for the Cassandra database for Nushell|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_cassandra_query](https://github.com/devyn/nu_plugin_cassandra_query)|0.3.0|Query plugin for the Cassandra database for Nushell|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_clipboard](https://github.com/FMotalleb/nu_plugin_clipboard)|0.101.1|A nushell plugin to copy text into clipboard or get text from it.|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_clipboard](https://github.com/FMotalleb/nu_plugin_clipboard)|0.102.0|A nushell plugin to copy text into clipboard or get text from it.|✅0.102.0|✅0.102.0|
 |[nu_plugin_compress](https://github.com/yybit/nu_plugin_compress)|0.2.3|A nushell plugin for compression and decompression, supporting zstd, gzip, bzip2, and xz.|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_dbus](https://github.com/devyn/nu_plugin_dbus)|0.14.0|Nushell plugin for communicating with D-Bus|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_dcm](https://github.com/realcundo/nu_plugin_dcm)|0.1.8|A nushell plugin to parse Dicom files|⚠️0.68|⚠️0.68|
-|[nu_plugin_desktop_notifications](https://github.com/FMotalleb/nu_plugin_desktop_notifications)|1.2.7|A nushell plugin to send desktop notifications|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_desktop_notifications](https://github.com/FMotalleb/nu_plugin_desktop_notifications)|1.2.8|A nushell plugin to send desktop notifications|✅0.102.0|✅0.102.0|
 |[nu_plugin_dialog](https://github.com/Trivernis/nu-plugin-dialog)|0.2.0|A nushell plugin for user interaction|⚠️0.86.1|⚠️0.86.1|
 |[nu_plugin_dns](https://github.com/dead10ck/nu_plugin_dns)|3.0.7-alpha.1|A DNS utility for nushell|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_dpkgtable](https://github.com/pdenapo/nu_plugin_dpkgtable)|0.1.0||⚠️0.91.0|⚠️0.91.0|
-|[nu_plugin_emoji](https://github.com/fdncred/nu_plugin_emoji)|0.10.0|a nushell plugin called emoji|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_emoji](https://github.com/fdncred/nu_plugin_emoji)|0.11.0|a nushell plugin called emoji|✅0.102.0|✅0.102.0|
 |[nu_plugin_endecode](https://github.com/KAAtheWiseGit/nugins/tree/trunk/endecode)|0.101.0|A plugin with various encoding schemes, from Crockford's base-32 to HTML entity escaping.|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_explore](https://github.com/amtoine/nu_plugin_explore)|0.100.0|A fast structured data explorer for Nushell.|⚠️0.100.0|⚠️0.100.0|
-|[nu_plugin_file](https://github.com/fdncred/nu_plugin_file)|0.12.0|a nushell plugin called file|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_explore](https://github.com/amtoine/nu_plugin_explore)|0.101.0|A fast structured data explorer for Nushell.|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_file](https://github.com/fdncred/nu_plugin_file)|0.13.0|a nushell plugin called file|✅0.102.0|✅0.102.0|
 |[nu_plugin_format_pcap](https://github.com/b4nst/nu_plugin_format_pcap)|0.1.0||⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_formats](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats)|0.102.0|An I/O plugin for a set of file formats for Nushell|✅0.102.0|✅0.102.0|
+|[nu_plugin_formats](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats)|0.102.1|An I/O plugin for a set of file formats for Nushell|✅0.102.1|✅0.102.1|
 |[nu_plugin_from_beancount](https://github.com/jcornaz/nu_plugin_from_beancount)|2.0.0|A nushell extension to load a beancount file into nu structured data|⚠️0.84.0|⚠️0.84.0|
 |[nu_plugin_from_bencode](https://github.com/bluk/nu_plugin_from_bencode)|0.11.0|A Nushell plugin to convert bencode data into Nu structured values.|⚠️0.93|⚠️0.93|
 |[nu_plugin_from_hdf5](https://github.com/Berrysoft/nu_plugin_from_hdf5)|0.1.0|A plugin to parse HDF5 files into nushell record.|⚠️0.100|⚠️0.100|
-|[nu_plugin_from_sse](https://github.com/cablehead/nu_plugin_from_sse)|0.101.0|Nushell plugin to convert a HTTP server sent event stream to structured data|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_gstat](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat)|0.102.0|A git status plugin for Nushell|✅0.102.0|✅0.102.0|
+|[nu_plugin_gstat](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat)|0.102.1|A git status plugin for Nushell|✅0.102.1|✅0.102.1|
 |[nu_plugin_hashes](https://github.com/ArmoredPony/nu_plugin_hashes)|0.1.5|A Nushell plugin that adds 61 cryptographic hash functions from Hashes project|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_hcl](https://github.com/Yethal/nu_plugin_hcl)|0.100.0|A nushell plugin for parsing Hashicorp Configuration Language file format|⚠️0.100.0|⚠️0.100.0|
-|[nu_plugin_highlight](https://github.com/cptpiepmatz/nu-plugin-highlight)|1.4.2+0.101.0|A nushell plugin for syntax highlighting|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_hmac](https://github.com/fnuttens/nu_plugin_hmac)|0.13.0|A HMAC sealing plugin for Nushell|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_image](https://github.com/FMotalleb/nu_plugin_image)|0.5.8|A nushell plugin to open png images in the shell and save ansi string as images (like tables or ...)|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_inc](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc)|0.102.0|A version incrementer plugin for Nushell|✅0.102.0|✅0.102.0|
-|[nu_plugin_json_path](https://github.com/fdncred/nu_plugin_json_path)|0.11.0|a nushell plugin created to parse json files using jsonpath|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_highlight](https://github.com/cptpiepmatz/nu-plugin-highlight)|1.4.3+0.102.0|A nushell plugin for syntax highlighting|✅0.102.0|✅0.102.0|
+|[nu_plugin_hmac](https://github.com/fnuttens/nu_plugin_hmac)|0.14.0|A HMAC sealing plugin for Nushell|✅0.102.0|✅0.102.0|
+|[nu_plugin_image](https://github.com/FMotalleb/nu_plugin_image)|0.102.0|A nushell plugin to open png images in the shell and save ansi string as images (like tables or ...)|✅0.102.0|✅0.102.0|
+|[nu_plugin_inc](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc)|0.102.1|A version incrementer plugin for Nushell|✅0.102.1|✅0.102.1|
+|[nu_plugin_json_path](https://github.com/fdncred/nu_plugin_json_path)|0.12.0|a nushell plugin created to parse json files using jsonpath|✅0.102.0|✅0.102.0|
 |[nu_plugin_kdl](https://github.com/amtoine/nu_plugin_kdl)|0.83.2|Add support for the KDL data format to Nushell.|⚠️0.83.2|⚠️0.83.2|
 |[nu_plugin_logfmt](https://github.com/oderwat/nu_plugin_logfmt)|0.1.0|Nushell plugin that allows conversion between logfmt and Nushell values.|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_mime](https://github.com/kik4444/nu_plugin_mime)|0.100.0|A simple plugin for working with mime types without performing disk access|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_mongo](https://github.com/WindSoilder/nu_plugin_mongo)|0.1.2|A nushell plugin to interactive with mongodb|⚠️0.101|⚠️0.101|
+|[nu_plugin_mongo](https://github.com/WindSoilder/nu_plugin_mongo)|0.1.3|A nushell plugin to interactive with mongodb|✅0.102|✅0.102|
 |[nu_plugin_msgpack](https://github.com/hulthe/nu_plugin_msgpack)|0.90.1|Commands to convert nushell data to and from MsgPack|⚠️0.90.1|⚠️0.90.1|
 |[nu_plugin_net](https://github.com/fennewald/nu_plugin_net)|1.8.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.98|⚠️0.98|
 |[nu_plugin_nupsql](https://gitlab.com/HertelP/nu_plugin_nupsql)|0.1.0|A nushell plugin to query postgres databases|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_parquet](https://github.com/fdncred/nu_plugin_parquet)|0.11.0|nu plugin to add parquet support|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_parquet](https://github.com/fdncred/nu_plugin_parquet)|0.12.0|nu plugin to add parquet support|✅0.102.0|✅0.102.0|
 |[nu_plugin_periodic_table](https://github.com/JosephTLyons/nu_plugin_periodic_table)|0.2.10|A periodic table of elements plugin for Nushell|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_plist](https://github.com/ainvaltin/nu_plugin_plist)|0.1.0|Nushell plist and base85 plugin implemented in Go.|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_plist](https://github.com/ayax79/nu_plugin_plist)|0.96.0|Plist parsing for nushell|⚠️0.96|⚠️0.96|
 |[nu_plugin_plot](https://github.com/Euphrasiologist/nu_plugin_plot)|0.91.1|Plot graphs in nushell using numerical lists.|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_plotters](https://github.com/cptpiepmatz/nu-jupyter-kernel/tree/main/crates/nu_plugin_plotters)|0.1.3+0.101.0|A nushell plugin for for plotting charts|⛔0.0.0|⛔0.0.0|
 |[nu_plugin_pnet](https://github.com/fdncred/nu_plugin_pnet)|1.7.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.97.2|⚠️0.97.2|
-|[nu_plugin_port_list](https://github.com/FMotalleb/nu_plugin_port_list)|1.4.6|A nushell plugin to list all active connections|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_port_scan](https://github.com/FMotalleb/nu_plugin_port_scan)|1.2.7|A nushell plugin for scanning ports on a target|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension)|0.102.1|A nushell plugin to list all active connections|✅0.102.0|✅0.102.0|
 |[nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)|0.7.0|A nushell plugin for querying prometheus|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_qr_maker](https://github.com/FMotalleb/nu_plugin_qr_maker)|1.1.0|A nushell plugin to create qr code in terminal|⚠️0.94.0|⚠️0.94.0|
-|[nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query)|0.102.0|A Nushell plugin to query JSON, XML, and various web data|✅0.102.0|✅0.102.0|
-|[nu_plugin_regex](https://github.com/fdncred/nu_plugin_regex)|0.10.0|nu plugin to search text with regex|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query)|0.102.1|A Nushell plugin to query JSON, XML, and various web data|✅0.102.1|✅0.102.1|
+|[nu_plugin_regex](https://github.com/fdncred/nu_plugin_regex)|0.11.0|nu plugin to search text with regex|✅0.102.0|✅0.102.0|
 |[nu_plugin_rpm](https://github.com/yybit/nu_plugin_rpm)|0.3.1|A nushell plugin for reading rpm package.|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_semver](https://github.com/abusch/nu_plugin_semver)|0.11.1|A nushell plugin for dealing with SemVer versions|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim)|0.11.1|An `sk` command that can handle Nushell's structured data|⚠️0.101|⚠️0.101|
+|[nu_plugin_semver](https://github.com/abusch/nu_plugin_semver)|0.11.2|A nushell plugin for dealing with SemVer versions|✅0.102.0|✅0.102.0|
+|[nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim)|0.12.0|An `sk` command that can handle Nushell's structured data|✅0.102|✅0.102|
 |[nu_plugin_sled](https://github.com/mrxiaozhuox/nu_plugin_sled)|0.1.0|Manage sled db in nushell|⚠️0.101|⚠️0.101|
 |[nu_plugin_str_similarity](https://github.com/fdncred/nu_plugin_str_similarity)|0.7.0|a nushell plugin called str_similarity|⚠️0.98.0|⚠️0.98.0|
 |[nu_plugin_template](https://github.com/KAAtheWiseGit/nugins/tree/trunk/template)|0.101.0|Templating in Nushell, powered by TinyTemplate|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_template](https://github.com/fdncred/nu_plugin_template)|0.0|A `cargo-generate` template for making it easier to create nushell plugins.|⛔0.0|⛔0.0|
-|[nu_plugin_ulid](https://github.com/lizclipse/nu_plugin_ulid)|0.10.0|A nushell plugin that adds various ulid commands|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_ulid](https://github.com/lizclipse/nu_plugin_ulid)|0.11.0|A nushell plugin that adds various ulid commands|✅0.102.0|✅0.102.0|
 |[nu_plugin_units](https://github.com/JosephTLyons/nu_plugin_units)|0.1.4|A Nushell plugin for easily converting between common units|⚠️0.101.0|⚠️0.101.0|
-|[nu_plugin_vec](https://github.com/PhotonBursted/nu_plugin_vec)|1.1.3|A Nushell plugin implementing vector operations|⚠️0.101.0|⚠️0.101.0|
+|[nu_plugin_vec](https://github.com/PhotonBursted/nu_plugin_vec)|1.1.4|A Nushell plugin implementing vector operations|✅0.102.0|✅0.102.0|
 |[nu_plugin_ws](https://github.com/alex-kattathra-johnson/nu_plugin_ws)|0.3.0|A Nushell plugin for easily streaming output from websocket endpoints|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_x509](https://github.com/yybit/nu_plugin_x509)|0.1.0|A nushell plugin for working with x509 certificates.|⚠️0.101.0|⚠️0.101.0|
 
-last update at `2025-02-05 03:14:59 +00:00`
+last update at `2025-02-10 18:10:15 +00:00`

--- a/plugin_details.md
+++ b/plugin_details.md
@@ -45,7 +45,7 @@
 |[nu_plugin_plot](https://github.com/Euphrasiologist/nu_plugin_plot)|0.91.1|Plot graphs in nushell using numerical lists.|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_plotters](https://github.com/cptpiepmatz/nu-jupyter-kernel/tree/main/crates/nu_plugin_plotters)|0.1.3+0.101.0|A nushell plugin for for plotting charts|⛔0.0.0|⛔0.0.0|
 |[nu_plugin_pnet](https://github.com/fdncred/nu_plugin_pnet)|1.7.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.97.2|⚠️0.97.2|
-|[nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension)|0.102.1|A nushell plugin to list all active connections|✅0.102.0|✅0.102.0|
+|[nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension)|0.102.1|A nushell plugin to list all active connections and scanning ports on a target address|✅0.102.0|✅0.102.0|
 |[nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)|0.7.0|A nushell plugin for querying prometheus|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_qr_maker](https://github.com/FMotalleb/nu_plugin_qr_maker)|1.1.0|A nushell plugin to create qr code in terminal|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query)|0.102.1|A Nushell plugin to query JSON, XML, and various web data|✅0.102.1|✅0.102.1|
@@ -63,4 +63,4 @@
 |[nu_plugin_ws](https://github.com/alex-kattathra-johnson/nu_plugin_ws)|0.3.0|A Nushell plugin for easily streaming output from websocket endpoints|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_x509](https://github.com/yybit/nu_plugin_x509)|0.1.0|A nushell plugin for working with x509 certificates.|⚠️0.101.0|⚠️0.101.0|
 
-last update at `2025-02-10 18:10:15 +00:00`
+last update at `2025-02-10 18:11:56 +00:00`

--- a/plugin_details.md
+++ b/plugin_details.md
@@ -45,7 +45,7 @@
 |[nu_plugin_plot](https://github.com/Euphrasiologist/nu_plugin_plot)|0.91.1|Plot graphs in nushell using numerical lists.|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_plotters](https://github.com/cptpiepmatz/nu-jupyter-kernel/tree/main/crates/nu_plugin_plotters)|0.1.3+0.101.0|A nushell plugin for for plotting charts|⛔0.0.0|⛔0.0.0|
 |[nu_plugin_pnet](https://github.com/fdncred/nu_plugin_pnet)|1.7.0|A nushell plugin for enumerating network interfaces in a platform-agnostic way|⚠️0.97.2|⚠️0.97.2|
-|[nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension)|0.102.1|A nushell plugin to list all active connections and scanning ports on a target address|✅0.102.0|✅0.102.0|
+|[nu_plugin_port_extension](https://github.com/FMotalleb/nu_plugin_port_extension)|0.102.1|A nushell plugin to list all active connections|✅0.102.0|✅0.102.0|
 |[nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)|0.7.0|A nushell plugin for querying prometheus|⚠️0.100.0|⚠️0.100.0|
 |[nu_plugin_qr_maker](https://github.com/FMotalleb/nu_plugin_qr_maker)|1.1.0|A nushell plugin to create qr code in terminal|⚠️0.94.0|⚠️0.94.0|
 |[nu_plugin_query](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_query)|0.102.1|A Nushell plugin to query JSON, XML, and various web data|✅0.102.1|✅0.102.1|
@@ -63,4 +63,4 @@
 |[nu_plugin_ws](https://github.com/alex-kattathra-johnson/nu_plugin_ws)|0.3.0|A Nushell plugin for easily streaming output from websocket endpoints|⚠️0.101.0|⚠️0.101.0|
 |[nu_plugin_x509](https://github.com/yybit/nu_plugin_x509)|0.1.0|A nushell plugin for working with x509 certificates.|⚠️0.101.0|⚠️0.101.0|
 
-last update at `2025-02-10 18:11:56 +00:00`
+last update at `2025-02-10 18:13:00 +00:00`


### PR DESCRIPTION
Major: Replaced both plugins with a single plugin that does both jobs with a bit cleaner codebase
Minor: bump nushell version in workflow