### PR TITLE
Add nu_plugin_bson to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -342,6 +342,11 @@ plugins:
     repository:
       url: https://github.com/dam4rus/nu_plugin_nuts
       branch: main
+  - name: nu_plugin_bson
+    language: rust
+    repository:
+      url: https://github.com/Kissaki/nu_plugin_bson
+      branch: main
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)


### PR DESCRIPTION
Missed in 84fa25029c9fb79a85409230393eef74f93a7b4e which added the plugin to the README.md plugin list.