### PR TITLE
add termplot (nu_plugin_termplot) to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_semver](https://github.com/abusch/nu_plugin_semver): A Nushell plugin to manipulate SemVer versions.
 - [nu_plugin_sled](https://github.com/mrxiaozhuox/nu_plugin_sled): A Nushell plugin for managing sled databases.
 - [nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim): A Nushell plugin that provides a version of [skim](https://github.com/lotabout/skim) that can handle structured Nushell data for macOS and Linux.
+- [nu_plugin_termplot](https://github.com/termplot/termplot): Beautiful plots in your terminal.
 - [nu_plugin_template (String and HTML templating)](https://codeberg.org/kaathewise/nugins/src/branch/trunk/template): String and HTML templating in Nu.
 - [nu_plugin_template (cargo-generate template)](https://github.com/nushell/nu_plugin_template): A `cargo-generate` template for making it easier to create nushell plugins.
 - [nu_plugin_ulid](https://github.com/lizclipse/nu_plugin_ulid): A nushell plugin that adds various ulid commands.

--- a/config.yaml
+++ b/config.yaml
@@ -352,7 +352,6 @@ plugins:
     repository:
       url: https://github.com/termplot/termplot
       branch: main
-  
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)


### PR DESCRIPTION
i recently shared this new plugin on discord with this information:

---

Today I'm happy to release the Nushell plugin for Termplot, which is a CLI tool for rendering beautiful plots directly in your terminal. Termplot works with and without Nushell. However, Nushell provides extra features. Termplot uses an entire web browser and web app to render a plot and then ansi escapes codes to render the plot in your terminal. Loading an entire web browser is slow for the ordinary CLI tool. However, the Nushell plugin manages the web browser in the background, making each plot render extremely fast.

Termplot is only tested in macOS! If anybody wants to fix the Windows/Linux support, I will happily accept PRs!

Learn more about Termplot and read installation instructions at the GitHub repo: https://github.com/termplot/termplot