### PR TITLE
add termplot with fixed config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_semver](https://github.com/abusch/nu_plugin_semver): A Nushell plugin to manipulate SemVer versions.
 - [nu_plugin_sled](https://github.com/mrxiaozhuox/nu_plugin_sled): A Nushell plugin for managing sled databases.
 - [nu_plugin_skim](https://github.com/idanarye/nu_plugin_skim): A Nushell plugin that provides a version of [skim](https://github.com/lotabout/skim) that can handle structured Nushell data for macOS and Linux.
+- [nu_plugin_termplot](https://github.com/termplot/termplot): Beautiful plots in your terminal.
 - [nu_plugin_template (String and HTML templating)](https://codeberg.org/kaathewise/nugins/src/branch/trunk/template): String and HTML templating in Nu.
 - [nu_plugin_template (cargo-generate template)](https://github.com/nushell/nu_plugin_template): A `cargo-generate` template for making it easier to create nushell plugins.
 - [nu_plugin_ulid](https://github.com/lizclipse/nu_plugin_ulid): A nushell plugin that adds various ulid commands.

--- a/config.yaml
+++ b/config.yaml
@@ -352,6 +352,13 @@ plugins:
     repository:
       url: https://github.com/termplot/termplot
       branch: main
+    override: # override fields because the plugin is written in typescript, and has no cargo.toml
+      name: "[nu_plugin_termplot](https://github.com/termplot/termplot)"
+      version: "0.1.21"
+      description: "Beautiful plots in your terminal."
+      plugin: "0.105.1"
+      protocol: "0.105.1"
+
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)

--- a/config.yaml
+++ b/config.yaml
@@ -347,6 +347,12 @@ plugins:
     repository:
       url: https://github.com/Kissaki/nu_plugin_bson
       branch: main
+  - name: nu_plugin_termplot
+    language: typescript
+    repository:
+      url: https://github.com/termplot/termplot
+      branch: main
+  
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)

--- a/config.yaml
+++ b/config.yaml
@@ -352,7 +352,6 @@ plugins:
     repository:
       url: https://github.com/termplot/termplot
       branch: main
-  
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)


### PR DESCRIPTION
This adds the termplot plugin to the list again because the previous PR was reverted due to a CI error.

This time I have added "override" config like some other non-Rust plugins.

The previous PR was here: https://github.com/nushell/awesome-nu/pull/127

I believe the issue was that the CI script assumes the presence of a Cargo.toml file. For non-Rust plugins like this one, there is no such Cargo.toml file. Instead, if the other plugins are a guide, one must use the "override" settings to put the values that would otherwise be taken from the Cargo.toml file.