### PR TITLE
Add nu_plugin_zstdsep to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can find some examples about how to create and use plugins in the [Nushell P
 - [nu_plugin_ws](https://github.com/alex-kattathra-johnson/nu_plugin_ws): A Nushell plugin for easily streaming output from websocket endpoints
 - [nu_plugin_x509](https://github.com/yybit/nu_plugin_x509): A Nushell plugin for parsing and generating x509 certificates.
 - [nu_plugin_handlebars](https://github.com/idanarye/nu_plugin_handlebars): An `handlebars` command for rendering Nu values using Handlebars templates.
+- [nu_plugin_zstdsep](https://github.com/kazu/seekzstdsep): A Nushell plugin for seekable, separator-aware zstd files(jsonl, csv, logfmt): open a `.seek.zst` and get any record without decompressing the file.
 
 > If the shell freezes while registering the command, that means the plugin is using an older Nu version no longer compatible with your current version. Consider bumping the Nu version to the latest in the `cargo.toml`, (may lead to breaking the script).
 

--- a/config.yaml
+++ b/config.yaml
@@ -442,7 +442,7 @@ plugins:
       url: https://github.com/kazu/seekzstdsep
       branch: master
     override:
-      name: "[nu_plugin_todoist](https://github.com/kazu/seekzstdsep)"
+      name: "[nu_plugin_zstdsep](https://github.com/kazu/seekzstdsep)"
       version: "0.2.2"
       description: "A Nushell plugin for seekable, separator-aware zstd files(jsonl, csv, logfmt)"
       plugin: "0.115.1"

--- a/config.yaml
+++ b/config.yaml
@@ -436,6 +436,17 @@ plugins:
       description: "A Nushell plugin for interacting with the Todoist API."
       plugin: "0.114.1"
       protocol: "0.114.1"
+  - name: nu_plugin_zstdsep
+    language: rust
+    repository:
+      url: https://github.com/kazu/seekzstdsep
+      branch: master
+    override:
+      name: "[nu_plugin_todoist](https://github.com/kazu/seekzstdsep)"
+      version: "0.2.2"
+      description: "A Nushell plugin for seekable, separator-aware zstd files(jsonl, csv, logfmt)"
+      plugin: "0.115.1"
+      protocol: "0.115.1"
 
 # Example
 #  - name: nu_plugin_bin_reader # the plugins name (mandatory)


### PR DESCRIPTION
 A Nushell plugin for seekable, separator-aware zstd files(jsonl, csv, logfmt): open a `.seek.zst` and get any record without decompressing the file.